### PR TITLE
Only reboot if required

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,3 +61,4 @@
 
 - name: reboot after installation
   win_reboot:
+  when: not vmware_tools_install.stat.exists


### PR DESCRIPTION
The server reboots if vmware tools is detected, this should be skipped if it's already installed.